### PR TITLE
Allow private screenshots on S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,7 @@ default:
           credentials_secret: AWS_S3_SECRET # Optional
           credentials_token: AWS_S3_TOKEN # Optional
           timeout: 30 # Optional, number of minutes the screenshot will be available when private
+          visibility: public-read # Optional, can be only public-read or private
 ```
 
 Usage

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ default:
           credentials_key: AWS_S3_KEY # Optional
           credentials_secret: AWS_S3_SECRET # Optional
           credentials_token: AWS_S3_TOKEN # Optional
+          timeout: 30 # Optional, number of minutes the screenshot will be available when private
 ```
 
 Usage

--- a/features/bootstrap/FeatureContext.php
+++ b/features/bootstrap/FeatureContext.php
@@ -29,7 +29,7 @@ class FeatureContext implements Context, SnippetAcceptingContext
      */
     public function iShouldSeeTheDummyImageUrl()
     {
-        $message = 'https://s3-eu-west-1.amazonaws.com/test_screenshot/1234/features_feature_feature_2.png';
+        $message = 'https://s3.eu-west-1.amazonaws.com/test_screenshot/1234/features_feature_feature_2.png';
 
         $output = $this->testRunnerContext->getStandardOutputMessage() .
             $this->testRunnerContext->getStandardErrorMessage();

--- a/src/AwsS3.php
+++ b/src/AwsS3.php
@@ -16,6 +16,7 @@ class AwsS3 implements ImageDriverInterface
     const CONFIG_PARAM_CREDENTIALS_TOKEN = 'credentials_token';
     const CONFIG_PARAM_CLIENT_FACTORY = 'client_factory';
     const CONFIG_PARAM_NAMESPACE = 'namespace';
+    const CONFIG_PARAM_TIMEOUT = 'timeout';
     /**
      * @var S3Client
      */
@@ -28,6 +29,10 @@ class AwsS3 implements ImageDriverInterface
      * @var string
      */
     private $namespace;
+    /**
+     * @var int
+     */
+    private $timeout;
 
     /**
      * @param  ArrayNodeDefinition $builder
@@ -44,6 +49,7 @@ class AwsS3 implements ImageDriverInterface
                 ->scalarNode(self::CONFIG_PARAM_CREDENTIALS_TOKEN)->defaultNull()->end()
                 ->scalarNode(self::CONFIG_PARAM_CLIENT_FACTORY)->defaultNull()->end()
                 ->scalarNode(self::CONFIG_PARAM_NAMESPACE)->defaultNull()->end()
+                ->integerNode(self::CONFIG_PARAM_TIMEOUT)->defaultValue(30)->end()
             ->end();
     }
 
@@ -53,6 +59,7 @@ class AwsS3 implements ImageDriverInterface
      */
     public function load(ContainerBuilder $container, array $config)
     {
+        $this->timeout = $config[self::CONFIG_PARAM_TIMEOUT];
         $this->bucket = $config[self::CONFIG_PARAM_BUCKET];
 
         $this->namespace = $config[self::CONFIG_PARAM_NAMESPACE]

--- a/src/AwsS3.php
+++ b/src/AwsS3.php
@@ -17,6 +17,7 @@ class AwsS3 implements ImageDriverInterface
     const CONFIG_PARAM_CLIENT_FACTORY = 'client_factory';
     const CONFIG_PARAM_NAMESPACE = 'namespace';
     const CONFIG_PARAM_TIMEOUT = 'timeout';
+    const CONFIG_PARAM_VISIBILITY = 'visibility';
     /**
      * @var S3Client
      */
@@ -33,6 +34,10 @@ class AwsS3 implements ImageDriverInterface
      * @var int
      */
     private $timeout;
+    /**
+     * @var string
+     */
+    private $visibility;
 
     /**
      * @param  ArrayNodeDefinition $builder
@@ -50,6 +55,10 @@ class AwsS3 implements ImageDriverInterface
                 ->scalarNode(self::CONFIG_PARAM_CLIENT_FACTORY)->defaultNull()->end()
                 ->scalarNode(self::CONFIG_PARAM_NAMESPACE)->defaultNull()->end()
                 ->integerNode(self::CONFIG_PARAM_TIMEOUT)->defaultValue(30)->end()
+                ->enumNode(self::CONFIG_PARAM_VISIBILITY)
+                    ->values(['public-read', 'private'])
+                    ->defaultValue('public-read')
+                ->end()
             ->end();
     }
 
@@ -61,6 +70,7 @@ class AwsS3 implements ImageDriverInterface
     {
         $this->timeout = $config[self::CONFIG_PARAM_TIMEOUT];
         $this->bucket = $config[self::CONFIG_PARAM_BUCKET];
+        $this->visibility = $config[self::CONFIG_PARAM_VISIBILITY];
 
         $this->namespace = $config[self::CONFIG_PARAM_NAMESPACE]
             ?: sprintf('%s-%04d', date('Y-m-d_H-i-s'), rand(0, 9999));


### PR DESCRIPTION
Screenshots can't be uploaded as private because the driver forces the visibility to `public-read` and doesn't give the temporary & signed URL.

Could this be a `0.1.4` version? Thanks