### PR TITLE
Update bex/behat-screenshot dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     "require": {
         "php": ">=5.4",
         "aws/aws-sdk-php": "^3.20",
-        "bex/behat-screenshot": "^1.0"
+        "bex/behat-screenshot": "^1.0 || ^2.0"
     },
     "require-dev": {
         "phpspec/phpspec" : "^2.4.0",


### PR DESCRIPTION
Update bex/behat-screenshot's dependency to either 1.0 or 2.0. This allows us to install this one along with other component which has dependency on bex/behat-screenshot 2.0, for example, acquia/blt-behat.